### PR TITLE
Token Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,16 @@ curl -X GET 'http://localhost:8000/api/schema'
 
 <details>
 
+#### General Auth
+
+There are currently several different ways that authentication can take place
+
+- HTTP Basic authentication can be used on all endpoints
+- HTTP Bearer authentication can be used with a Read/Write API token
+- In URL Read token (READ only) `/token/<token>/api` can be used for editors that
+  aren't able to pass authentication via a header. Any readonly API can be accessed
+- Session cookie based authentication
+
 #### `GET` `/api/auth`
 
 Returns a JSON object containing the servers auth permissions as defined by the default

--- a/hecate/src/auth/mod.rs
+++ b/hecate/src/auth/mod.rs
@@ -318,7 +318,6 @@ impl Auth {
                 match base64::decode(&authtype.split_off(6)) {
                     Ok(decoded) => match String::from_utf8(decoded) {
                         Ok(decoded_str) => {
-
                             let split = decoded_str.split(':').collect::<Vec<&str>>();
 
                             if split.len() != 2 { return Err(HecateError::new(401, String::from("Unauthorized"), None)); }
@@ -412,8 +411,8 @@ impl Auth {
             match conn.query("
                 SELECT
                     users_tokens.uid,
-                    users.access,
-                    users.scope
+                    users_tokens.scope,
+                    users.access
                 FROM
                     users_tokens,
                     users

--- a/hecate/src/auth/mod.rs
+++ b/hecate/src/auth/mod.rs
@@ -433,15 +433,9 @@ impl Auth {
                     let access: Option<String> = res.get(0).get(1);
                     let scope: Option<String> = res.get(0).get(2);
 
-                    let scope = match scope {
-                        Some(scope) => {
-                            if scope == "" {
-                                Scope::Read
-                            } else {
-                                Scope::Read
-                            }
-                        },
-                        None => Scope::Read
+                    let scope = match &scope {
+                        None => Scope::Read,
+                        Some(scope) => Scope::from_str(scope)?
                     };
 
                     let access = match access {

--- a/hecate/src/auth/mod.rs
+++ b/hecate/src/auth/mod.rs
@@ -2,6 +2,7 @@ use crate::err::HecateError;
 use actix_http::httpmessage::HttpMessage;
 use actix_web::http::header::{HeaderName, HeaderValue};
 use std::default::Default;
+use std::str::FromStr;
 
 pub mod config;
 pub mod middleware;
@@ -215,10 +216,7 @@ impl Auth {
             scope: match headers.get("hecate_scope") {
                 None => Scope::Read,
                 Some(scope) => match scope.to_str() {
-                    Ok(scope) => match scope {
-                        "full" => Scope::Full,
-                        _ => Scope::Read
-                    },
+                    Ok(scope) => Scope::from_str(scope)?,
                     Err(err) => {
                         return Err(HecateError::new(500, String::from("Authentication Error"), Some(err.to_string())));
                     }
@@ -285,14 +283,22 @@ impl Auth {
             let new_url =  actix_web::dev::Url::new(new_path.parse::<actix_web::http::Uri>().unwrap());
             curr_path.set(new_url);
 
-        } 
-        
+            // The /token/{token} path is special and does not use the
+            // validate() call below as tokens used in URL are currently
+            // only able to perform Read operations
+            auth.validate(conn)?;
+
+            auth.scope = Scope::Read;
+
+            return Ok(auth);
+        }
+
         if let Some(token) = req.cookie("session") {
             let token = String::from(token.value());
 
             if !token.is_empty() {
                 auth.token = Some(token);
-                auth.scope = Scope::Full;
+
                 return match auth.validate(conn) {
                     Err(err) => {
                         return Err(err.set_invalidate(true));
@@ -303,35 +309,33 @@ impl Auth {
         }
 
         if let Some(key) = req.headers().get("Authorization") {
-            if key.len() < 7 {
-                return Ok(auth);
-            }
-
             let mut authtype = match key.to_str() {
                 Ok(key) => key.to_string(),
-                Err(_) => { return Err(HecateError::new(401, String::from("Unauthorized"), None)); }
+                Err(err) => { return Err(HecateError::new(401, String::from("Unauthorized"), Some(err.to_string()))); }
             };
-            let auth_str = authtype.split_off(6);
 
-            if authtype != "Basic " {
+            if authtype.starts_with("Basic ") {
+                match base64::decode(&authtype.split_off(6)) {
+                    Ok(decoded) => match String::from_utf8(decoded) {
+                        Ok(decoded_str) => {
+
+                            let split = decoded_str.split(':').collect::<Vec<&str>>();
+
+                            if split.len() != 2 { return Err(HecateError::new(401, String::from("Unauthorized"), None)); }
+
+                            auth.basic = Some((String::from(split[0]), String::from(split[1])));
+                            auth.scope = Scope::Full;
+                        },
+                        Err(err) => { return Err(HecateError::new(401, String::from("Unauthorized"), Some(err.to_string()))); }
+                    },
+                    Err(err) => { return Err(HecateError::new(401, String::from("Unauthorized"), Some(err.to_string()))); }
+                }
+            } else if authtype.starts_with("Bearer ") {
+                auth.token = Some(authtype.split_off(7));
+            } else {
                 return Ok(auth);
             }
 
-            match base64::decode(&auth_str) {
-                Ok(decoded) => match String::from_utf8(decoded) {
-                    Ok(decoded_str) => {
-
-                        let split = decoded_str.split(':').collect::<Vec<&str>>();
-
-                        if split.len() != 2 { return Err(HecateError::new(401, String::from("Unauthorized"), None)); }
-
-                        auth.basic = Some((String::from(split[0]), String::from(split[1])));
-                        auth.scope = Scope::Full;
-                    },
-                    Err(_err) => { return Err(HecateError::new(401, String::from("Unauthorized"), None)); }
-                },
-                Err(_err) => { return Err(HecateError::new(401, String::from("Unauthorized"), None)); }
-            }
         }
 
         auth.validate(conn)?;
@@ -345,10 +349,11 @@ impl Auth {
     /// Used as a generic function by validate to ensure future
     /// authentication methods are cleared with each validate
     ///
-    pub fn secure(&mut self, user: Option<(i64, AuthAccess)>) {
+    pub fn secure(&mut self, user: Option<(i64, AuthAccess, Scope)>) {
         if let Some(user) = user {
             self.uid = Some(user.0);
             self.access = user.1;
+            self.scope = user.2;
         }
 
         self.token = None;
@@ -395,7 +400,7 @@ impl Auth {
                         None => AuthAccess::Default
                     };
 
-                    self.secure(Some((uid, access)));
+                    self.secure(Some((uid, access, self.scope.clone())));
 
                     return Ok(true);
                 },
@@ -407,7 +412,8 @@ impl Auth {
             match conn.query("
                 SELECT
                     users_tokens.uid,
-                    users.access
+                    users.access,
+                    users.scope
                 FROM
                     users_tokens,
                     users
@@ -426,6 +432,18 @@ impl Auth {
 
                     let uid: i64 = res.get(0).get(0);
                     let access: Option<String> = res.get(0).get(1);
+                    let scope: Option<String> = res.get(0).get(2);
+
+                    let scope = match scope {
+                        Some(scope) => {
+                            if scope == "" {
+                                Scope::Read
+                            } else {
+                                Scope::Read
+                            }
+                        },
+                        None => Scope::Read
+                    };
 
                     let access = match access {
                         Some(access) => {
@@ -440,7 +458,7 @@ impl Auth {
                         None => AuthAccess::Default
                     };
 
-                    self.secure(Some((uid, access)));
+                    self.secure(Some((uid, access, scope)));
 
                     return Ok(true);
                 },

--- a/hecate/src/auth/mod.rs
+++ b/hecate/src/auth/mod.rs
@@ -428,10 +428,9 @@ impl Auth {
                     if res.is_empty() {
                         return Err(config::not_authed());
                     }
-
                     let uid: i64 = res.get(0).get(0);
-                    let access: Option<String> = res.get(0).get(1);
-                    let scope: Option<String> = res.get(0).get(2);
+                    let scope: Option<String> = res.get(0).get(1);
+                    let access: Option<String> = res.get(0).get(2);
 
                     let scope = match &scope {
                         None => Scope::Read,

--- a/hecate/src/user/token.rs
+++ b/hecate/src/user/token.rs
@@ -1,4 +1,5 @@
 use crate::err::HecateError;
+use std::str::FromStr;
 
 #[derive(Deserialize, Serialize, PartialEq, Clone, Debug)]
 pub enum Scope {
@@ -11,6 +12,18 @@ impl ToString for Scope {
         match self {
             Scope::Read => String::from("read"),
             Scope::Full => String::from("full")
+        }
+    }
+}
+
+impl FromStr for Scope {
+    type Err = HecateError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "read" => Ok(Scope::Read),
+            "full" => Ok(Scope::Full),
+            _ => Err(HecateError::new(500, String::from("Authentication Error: Scope Mismatch"), None))
         }
     }
 }

--- a/hecate/tests/token.rs
+++ b/hecate/tests/token.rs
@@ -134,6 +134,7 @@ mod test {
             }
 
             { // Access the feature create (FULL scope) endpoint with token and basic auth
+              // Will fail as token auth is considered first
                 let client = reqwest::Client::new();
                 let resp = client.post(format!("http://0.0.0.0:8000/token/{}/api/data/feature", token).as_str())
                     .body(r#"{
@@ -148,7 +149,7 @@ mod test {
                     .send()
                     .unwrap();
 
-                assert_eq!(resp.status().as_u16(), 200);
+                assert_eq!(resp.status().as_u16(), 401);
             }
 
             { // Access the Tokens List

--- a/hecate/tests/user_bearer.rs
+++ b/hecate/tests/user_bearer.rs
@@ -1,0 +1,199 @@
+extern crate reqwest;
+extern crate postgres;
+#[macro_use] extern crate serde_json;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::env;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use reqwest;
+
+    #[test]
+    fn user_bearer() {
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("
+                DROP DATABASE IF EXISTS hecate;
+            ", &[]).unwrap();
+
+            conn.execute("
+                CREATE DATABASE hecate;
+            ", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.default.json").to_str().unwrap()
+        ]).spawn().unwrap();
+
+        thread::sleep(Duration::from_secs(1));
+
+        { // Create User
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+            conn.execute("
+                INSERT INTO users (username, password, email, access)
+                    VALUES ('ingalls', crypt('yeahehyeah', gen_salt('bf', 10)), 'ingalls@protonmail.com', 'default')
+            ", &[]).unwrap();
+        }
+
+        { // Attempt to access default server
+            let mut resp = reqwest::get("http://0.0.0.0:8000/").unwrap();
+            assert_eq!(resp.status().as_u16(), 200);
+            assert_eq!(resp.text().unwrap(), "Hello World!");
+        }
+
+        { // READ TOKEN
+            let token: String;
+
+            { // Create Token
+                let client = reqwest::Client::new();
+
+                let mut resp = client.post("http://0.0.0.0:8000/api/user/token")
+                    .body(r#"{
+                        "name": "API Token",
+                        "scope": "read",
+                        "hours": 5
+                    }"#)
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                let json_body: serde_json::value::Value = resp.json().unwrap();
+
+                assert_eq!(json_body["name"], json!("API Token"));
+                assert_eq!(json_body["uid"], json!(1));
+
+                assert!(resp.status().is_success());
+
+                token = json_body["token"].as_str().unwrap().to_string();
+            }
+
+            { // Access the capabilities endpoint without token
+                let resp = reqwest::get("http://0.0.0.0:8000/api/capabilities").unwrap();
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+
+            { // Access the capabilities endpoint with token
+                let resp = reqwest::get(format!("http://0.0.0.0:8000/token/{}/api/capabilities", token).as_str()).unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { // Access the capabilities endpoint with bearer token
+                let client = reqwest::Client::new();
+                let resp = client.get("http://0.0.0.0:8000/api/capabilities")
+                    .bearer_auth(&token)
+                    .send()
+                    .unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { //Fail Create Point due to read scope
+                let client = reqwest::Client::new();
+                let resp = client.post("http://0.0.0.0:8000/api/data/feature")
+                    .body(r#"{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                    }"#)
+                    .bearer_auth(&token)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+        }
+
+        { // FULL TOKEN
+            let token: String;
+
+            { // Create Token
+                let client = reqwest::Client::new();
+
+                let mut resp = client.post("http://0.0.0.0:8000/api/user/token")
+                    .body(r#"{
+                        "name": "API Token",
+                        "scope": "full",
+                        "hours": 5
+                    }"#)
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                let json_body: serde_json::value::Value = resp.json().unwrap();
+
+                assert_eq!(json_body["name"], json!("API Token"));
+                assert_eq!(json_body["uid"], json!(1));
+
+                assert!(resp.status().is_success());
+
+                token = json_body["token"].as_str().unwrap().to_string();
+            }
+
+            { // Access the capabilities endpoint without token
+                let resp = reqwest::get("http://0.0.0.0:8000/api/capabilities").unwrap();
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+
+            { // Access the capabilities endpoint with token
+                let resp = reqwest::get(format!("http://0.0.0.0:8000/token/{}/api/capabilities", token).as_str()).unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { // Access the capabilities endpoint with bearer token
+                let client = reqwest::Client::new();
+                let resp = client.get("http://0.0.0.0:8000/api/capabilities")
+                    .bearer_auth(&token)
+                    .send()
+                    .unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { //Fail Create Point due to read scope
+                let client = reqwest::Client::new();
+                let resp = client.post("http://0.0.0.0:8000/api/data/feature")
+                    .body(r#"{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                    }"#)
+                    .bearer_auth(&token)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+        }
+
+        server.kill().unwrap();
+    }
+}


### PR DESCRIPTION
### Context

At the moment there is limited use for tokens, despite adding several improved UI & API flows for creating them.

Supported Methods Include
- In URL Readonly Token
- Basic HTTP Auth
- Session Cookie Auth

This PR introduces Token based auth in the form of supoort for HTTP Bearer Authentication. See the README on authentication when this is merged for more information.

cc/ @ingalls @kamicut 
