### PR TITLE
Feature revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1490,6 +1490,31 @@ curl -X GET 'http://localhost:8000/api/data/feature/1542'
 
 ---
 
+#### `DELETE` `/api/data/feature/<id>`
+
+Permanently remove a feature from the system including
+- Active feature
+- All past history of the feature
+- Any reference to the feature in stored deltas
+
+This action is internally called a `hard delete`
+
+Note: Only an `admin` user can perform a hard delete.
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<id>` | `REQUIRED` Numeric ID of a given feature to delete |
+
+*Example*
+
+```bash
+curl -X DELETE 'http://localhost:8000/api/data/feature/1542'
+```
+
+---
+
 #### `GET` `/api/data/feature/<id>/history`
 
 Return an array containing the full feature history for the provided feature id.

--- a/hecate/src/err/mod.rs
+++ b/hecate/src/err/mod.rs
@@ -120,6 +120,12 @@ impl std::fmt::Display for HecateError {
     }
 }
 
+impl std::convert::From<HecateError> for actix_threadpool::BlockingError<HecateError> {
+    fn from(payload: HecateError) -> Self {
+        actix_threadpool::BlockingError::Error(payload)
+    }
+}
+
 impl std::convert::From<actix_http::error::PayloadError> for HecateError {
     fn from(payload: actix_http::error::PayloadError) -> Self {
         HecateError::new(500, String::from("Internal Server Error"), Some(payload.to_string()))

--- a/hecate/src/feature/mod.rs
+++ b/hecate/src/feature/mod.rs
@@ -915,3 +915,21 @@ pub fn get_bbox_history_stream(conn: r2d2::PooledConnection<r2d2_postgres::Postg
             ) f;
     "#), &[&bbox[0], &bbox[1], &bbox[2], &bbox[3]])?)
 }
+
+pub fn hard_delete(trans: &postgres::transaction::Transaction, feature_id: i64) -> Result<(), HecateError> {
+    if let Err(err) = conn.execute("
+        DELETE FROM geo
+            WHERE
+                id = $1
+    ", &[&feature_id]) {
+        return Err(HecateError::new(500, String::from("Failed to Hard Delete"), err.to_string()));
+    }
+
+    if let Err(err) = conn.execute("
+        DELETE FROM geo_history
+            WHERE
+                id = $1
+    ", &[&feature_id]) {
+        return Err(HecateError::new(500, String::from("Failed to Hard Delete"), err.to_string()));
+    }
+}

--- a/hecate/tests/feature_delete.rs
+++ b/hecate/tests/feature_delete.rs
@@ -1,0 +1,168 @@
+extern crate reqwest;
+extern crate postgres;
+#[macro_use] extern crate serde_json;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use reqwest;
+    use serde_json;
+
+    #[test]
+    fn feature_delete() {
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("
+                DROP DATABASE IF EXISTS hecate;
+            ", &[]).unwrap();
+
+            conn.execute("
+                CREATE DATABASE hecate;
+            ", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
+        thread::sleep(Duration::from_secs(1));
+
+        { //Create Username
+            let mut resp = reqwest::get("http://0.0.0.0:8000/api/user/create?username=ingalls&password=yeahehyeah&email=ingalls@protonmail.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://0.0.0.0:8000/api/data/features")
+                .body(r#"{
+                    "type": "FeatureCollection",
+                    "message": "Create Intial Delta",
+                    "features": [{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                    },{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                    }]
+                }"#)
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Modify Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://0.0.0.0:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 1,
+                    "action": "modify",
+                    "message": "Modify a Point",
+                    "properties": { "number": "123", "test": true },
+                    "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+            assert_eq!(resp.text().unwrap(), "true");
+        }
+
+        { // Retrieve delta 1 and ensure both points are present
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://0.0.0.0:8000/api/delta/1")
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .send()
+                .unwrap();
+
+            let json_body: serde_json::Value = resp.json().unwrap();
+
+            assert_eq!(json_body["affected"], json!([1, 2]));
+            assert!(resp.status().is_success());
+        }
+
+        { // Retrieve feature 1 history
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://0.0.0.0:8000/api/data/feature/1/history")
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .send()
+                .unwrap();
+
+            let json_body: serde_json::Value = resp.json().unwrap();
+
+            assert_eq!(json_body.as_array().unwrap().len(), 2);
+            assert!(resp.status().is_success());
+        }
+
+        { // Hard Delete Feature 1
+            let client = reqwest::Client::new();
+            let mut resp = client.delete("http://0.0.0.0:8000/api/data/feature/1")
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .send()
+                .unwrap();
+
+            let json_body: serde_json::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!(true));
+            assert!(resp.status().is_success());
+        }
+
+        { // Retrieve delta 1 and ensure only #2 point is present
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://0.0.0.0:8000/api/delta/1")
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .send()
+                .unwrap();
+
+            let json_body: serde_json::Value = resp.json().unwrap();
+
+            assert_eq!(json_body["affected"], json!([2]));
+            assert!(resp.status().is_success());
+        }
+
+        { // Retrieve feature 1 history
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://0.0.0.0:8000/api/data/feature/1/history")
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.status().as_u16(), 200);
+        }
+
+        server.kill().unwrap();
+    }
+}

--- a/hecate/tests/feature_delete.rs
+++ b/hecate/tests/feature_delete.rs
@@ -155,7 +155,7 @@ mod test {
 
         { // Retrieve feature 1 history
             let client = reqwest::Client::new();
-            let mut resp = client.get("http://0.0.0.0:8000/api/data/feature/1/history")
+            let resp = client.get("http://0.0.0.0:8000/api/data/feature/1/history")
                 .basic_auth("ingalls", Some("yeahehyeah"))
                 .send()
                 .unwrap();


### PR DESCRIPTION
### Context

Although we currently support reverting deltas via the `revert` subcommand found in HecateJS, there is currently no way to permanently remove features from the datastore.

This PR introduces a feature by feature deletion endpoint that permanently alters history.

cc/ @ingalls
