### PR TITLE
Add semver parsing to database check for PostgreSQL and PostGIS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "r2d2_postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hecate_derive 0.1.0",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgis 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/hecate/Cargo.toml
+++ b/hecate/Cargo.toml
@@ -42,6 +42,7 @@ hmac = "0.7"
 url = "2.1"
 sha2 = "0.8.0"
 semver = "0.9.0"
+lazy_static = "1.4.0"
 
 [dependencies.geo]
 version = "0.12"

--- a/hecate/Cargo.toml
+++ b/hecate/Cargo.toml
@@ -41,6 +41,7 @@ env_logger = "0.7"
 hmac = "0.7"
 url = "2.1"
 sha2 = "0.8.0"
+semver = "0.9.0"
 
 [dependencies.geo]
 version = "0.12"

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -1,6 +1,10 @@
-pub static VERSION: &str = "0.86.1";
-pub static POSTGRES: f64 = 10.0;
-pub static POSTGIS: f64 = 2.4;
+/// Hecate version
+pub static VERSION: &str = "0.86.0"; // must parse as semver::Version
+/// Supported version of PostgreSQL
+pub static POSTGRES_VERSION: &str = ">= 11.0.0"; // must parse as semver::VersionReq
+/// Supported version of PostGIS
+pub static POSTGIS_VERSION: &str = ">= 2.5.0"; // must parse as semver::VersionReq
+
 pub static HOURS: i64 = 24;
 
 ///

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -1,9 +1,18 @@
-/// Hecate version
-pub static VERSION: &str = "0.86.1"; // must parse as semver::Version
-/// Supported version of PostgreSQL
-pub static POSTGRES_VERSION: &str = ">= 11.0.0"; // must parse as semver::VersionReq
-/// Supported version of PostGIS
-pub static POSTGIS_VERSION: &str = ">= 2.5.0"; // must parse as semver::VersionReq
+#[macro_use]
+extern crate lazy_static;
+
+use semver::VersionReq;
+
+lazy_static! {
+    pub static ref POSTGRES_VERSION: VersionReq = match VersionReq::parse(">= 11.0.0") {
+        Ok(v) => v,
+        Err(_) => panic!("Failed to parse POSTGRES_VERSION as semver::VersionReq")
+    };
+    pub static ref POSTGIS_VERSION: VersionReq = match VersionReq::parse(">= 2.5.0") {
+        Ok(v) => v,
+        Err(_) => panic!("Failed to parse POSTGIS_VERSION as semver::VersionReq")
+    };
+}
 
 pub static HOURS: i64 = 24;
 
@@ -349,7 +358,7 @@ fn server(
     auth::check(&auth_rules.0.server, auth::RW::Read, &auth)?;
 
     Ok(Json(json!({
-        "version": VERSION,
+        "version": env!("CARGO_PKG_VERSION"),
         "constraints": {
             "request": {
                 "max_size": MAX_BODY

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -1,5 +1,5 @@
 /// Hecate version
-pub static VERSION: &str = "0.86.0"; // must parse as semver::Version
+pub static VERSION: &str = "0.86.1"; // must parse as semver::Version
 /// Supported version of PostgreSQL
 pub static POSTGRES_VERSION: &str = ">= 11.0.0"; // must parse as semver::VersionReq
 /// Supported version of PostGIS

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -4,14 +4,10 @@ extern crate lazy_static;
 use semver::VersionReq;
 
 lazy_static! {
-    pub static ref POSTGRES_VERSION: VersionReq = match VersionReq::parse(">= 11.0.0") {
-        Ok(v) => v,
-        Err(_) => panic!("Failed to parse POSTGRES_VERSION as semver::VersionReq")
-    };
-    pub static ref POSTGIS_VERSION: VersionReq = match VersionReq::parse(">= 2.5.0") {
-        Ok(v) => v,
-        Err(_) => panic!("Failed to parse POSTGIS_VERSION as semver::VersionReq")
-    };
+    pub static ref POSTGRES_VERSION: VersionReq = VersionReq::parse(">= 11.0.0")
+        .expect("Failed to parse POSTGRES_VERSION as semver::VersionReq");
+    pub static ref POSTGIS_VERSION: VersionReq = VersionReq::parse(">= 2.5.0")
+        .expect("Failed to parse POSTGIS_VERSION as semver::VersionReq");
 }
 
 pub static HOURS: i64 = 24;

--- a/hecate/src/main.rs
+++ b/hecate/src/main.rs
@@ -160,9 +160,6 @@ fn database_check(conn_str: &String, is_read: bool) {
                                 got_postgres_v
                             );
                         }
-
-                        println!("want {}, got {}", want_postgres_v.to_string(), got_postgres_v.to_string());
-
                         let postgis_v: String = res.get(0).get(1);
                         let want_postgis_v = VersionReq::parse(hecate::POSTGIS_VERSION).unwrap();
                         let got_postgis_v = match Version::parse(&postgis_v){
@@ -172,8 +169,6 @@ fn database_check(conn_str: &String, is_read: bool) {
                                 Version::parse(&fix_semver).unwrap()
                             }
                         };
-                        println!("want {}, got {}", want_postgis_v.to_string(), got_postgis_v.to_string());
-
                         if ! want_postgis_v.matches(&got_postgis_v) {
                             panic!(
                                 "ERROR: Hecate requires a min PostGIS version of {}, got {}.", 

--- a/hecate/src/main.rs
+++ b/hecate/src/main.rs
@@ -12,7 +12,6 @@ use hecate::auth::AuthModule;
 use std::error::Error;
 use clap::App;
 use semver::Version;
-use semver::VersionReq;
 
 fn main() {
     let cli_cnf = load_yaml!("cli.yml");
@@ -145,34 +144,36 @@ fn database_check(conn_str: &String, is_read: bool) {
                             std::process::exit(1);
                         }
                         let postgres_v: String = res.get(0).get(0);
-                        let want_postgres_v = VersionReq::parse(hecate::POSTGRES_VERSION).unwrap();
                         let got_postgres_v = match Version::parse(&postgres_v){
                             Ok(version) => version,
                             Err(_) => {
                                 let fix_semver = format!("{}.0", postgres_v);
-                                Version::parse(&fix_semver).unwrap()
+                                Version::parse(&fix_semver).expect(
+                                    format!("Failed to parse semver for PostgreSQL {}.", fix_semver).as_str()
+                                )
                             }
                         };
-                        if ! want_postgres_v.matches(&got_postgres_v) {
+                        if ! hecate::POSTGRES_VERSION.matches(&got_postgres_v) {
                             panic!(
-                                "ERROR: Hecate requires a min PostgreSQL version of {}, got {}.", 
-                                want_postgres_v.to_string(),
+                                "ERROR: Hecate requires PostgreSQL version {}, got {}.", 
+                                hecate::POSTGRES_VERSION.to_string(),
                                 got_postgres_v
                             );
                         }
                         let postgis_v: String = res.get(0).get(1);
-                        let want_postgis_v = VersionReq::parse(hecate::POSTGIS_VERSION).unwrap();
                         let got_postgis_v = match Version::parse(&postgis_v){
                             Ok(version) => version,
                             Err(_) => {
                                 let fix_semver = format!("{}.0", postgis_v);
-                                Version::parse(&fix_semver).unwrap()
+                                Version::parse(&fix_semver).expect(
+                                    format!("Failed to parse semver for PostGIS {}", fix_semver).as_str()
+                                )
                             }
                         };
-                        if ! want_postgis_v.matches(&got_postgis_v) {
+                        if ! hecate::POSTGIS_VERSION.matches(&got_postgis_v) {
                             panic!(
-                                "ERROR: Hecate requires a min PostGIS version of {}, got {}.", 
-                                want_postgis_v.to_string(),
+                                "ERROR: Hecate requires PostGIS version {}, got {}.",
+                                hecate::POSTGIS_VERSION.to_string(),
                                 got_postgis_v
                             );
                         }

--- a/hecate/src/main.rs
+++ b/hecate/src/main.rs
@@ -11,6 +11,8 @@ use hecate::auth::CustomAuth;
 use hecate::auth::AuthModule;
 use std::error::Error;
 use clap::App;
+use semver::Version;
+use semver::VersionReq;
 
 fn main() {
     let cli_cnf = load_yaml!("cli.yml");
@@ -134,29 +136,54 @@ fn database_check(conn_str: &String, is_read: bool) {
             if !is_read {
                 match conn.query("
                     SELECT
-                        (regexp_matches(version(), 'PostgreSQL (.*?) '))[1]::FLOAT AS postgres_v,
-                        (regexp_matches(postgis_version(), '^(.*?) '))[1]::FLOAT AS postgis_v
+                        (regexp_matches(version(), 'PostgreSQL (.*?) '))[1] AS postgres_v,
+                        (regexp_matches(postgis_version(), '^(.*?) '))[1] AS postgis_v
                 ", &[]) {
                     Ok(res) => {
                         if res.len() != 1 {
-                            println!("ERROR: Connection unable obtain postgres version using ({}) {}", conn_type, conn_str);
+                            println!("ERROR: Connection unable obtain PostgreSQL version using ({}) {}", conn_type, conn_str);
                             std::process::exit(1);
                         }
-
-                        let postgres_v: f64 = res.get(0).get(0);
-                        if postgres_v < hecate::POSTGRES {
-                            println!("ERROR: Hecate requires a min postgres version of {}", hecate::POSTGRES);
-                            std::process::exit(1);
+                        let postgres_v: String = res.get(0).get(0);
+                        let want_postgres_v = VersionReq::parse(hecate::POSTGRES_VERSION).unwrap();
+                        let got_postgres_v = match Version::parse(&postgres_v){
+                            Ok(version) => version,
+                            Err(_) => {
+                                let fix_semver = format!("{}.0", postgres_v);
+                                Version::parse(&fix_semver).unwrap()
+                            }
+                        };
+                        if ! want_postgres_v.matches(&got_postgres_v) {
+                            panic!(
+                                "ERROR: Hecate requires a min PostgreSQL version of {}, got {}.", 
+                                want_postgres_v.to_string(),
+                                got_postgres_v
+                            );
                         }
 
-                        let postgis_v: f64 = res.get(0).get(1);
-                        if postgis_v < hecate::POSTGIS {
-                            println!("ERROR: Hecate requires a min postgis version of {}", hecate::POSTGIS);
-                            std::process::exit(1);
+                        println!("want {}, got {}", want_postgres_v.to_string(), got_postgres_v.to_string());
+
+                        let postgis_v: String = res.get(0).get(1);
+                        let want_postgis_v = VersionReq::parse(hecate::POSTGIS_VERSION).unwrap();
+                        let got_postgis_v = match Version::parse(&postgis_v){
+                            Ok(version) => version,
+                            Err(_) => {
+                                let fix_semver = format!("{}.0", postgis_v);
+                                Version::parse(&fix_semver).unwrap()
+                            }
+                        };
+                        println!("want {}, got {}", want_postgis_v.to_string(), got_postgis_v.to_string());
+
+                        if ! want_postgis_v.matches(&got_postgis_v) {
+                            panic!(
+                                "ERROR: Hecate requires a min PostGIS version of {}, got {}.", 
+                                want_postgis_v.to_string(),
+                                got_postgis_v
+                            );
                         }
                     },
                     Err(err) => {
-                        println!("ERROR: Connection unable obtain postgres version using ({}) {}", conn_type, conn_str);
+                        println!("ERROR: Connection unable obtain PostgreSQL version using ({}) {}", conn_type, conn_str);
                         println!("ERROR: {}", err.description());
                         println!("ERROR: Caused by: {}", err.source().unwrap());
                         std::process::exit(1);

--- a/release
+++ b/release
@@ -56,15 +56,6 @@ if [[ ! $(git diff hecate/Cargo.toml | grep '^+' | wc -l | awk '{print $1}') -eq
     exit 1
 fi
 
-sed -i.bak "s/\"$CVER\"/\"$NVER\"/" ./hecate/src/lib.rs
-rm -f ./hecate/src/lib.rs.bak
-echo "ok - Updated hecate/src/lib.rs"
-
-if [[ ! $(git diff ./hecate/src/lib.rs | grep '^+' | wc -l | awk '{print $1}') -eq 2 ]]; then
-    echo "not ok - Failed to update hecate/src/lib.rs"
-    exit 1
-fi
-
 sed -i.bak "s/$CVER/$NVER/" ./hecate/src/cli.yml
 rm -f ./hecate/src/cli.yml.bak
 echo "ok - Updated hecate/src/cli.yml"


### PR DESCRIPTION
### Context
Fixes #1

The `version()` check for PostgreSQL and PostGIS fails on 9.x because the value cannot always be parsed as a float, e.g. `9.6.16`.  Here is an example error from `psql`

```sql
SELECT
 (regexp_matches(version(), 'PostgreSQL (.*?) '))[1]::FLOAT AS postgres_v,
 (regexp_matches(postgis_version(), '^(.*?) '))[1]::FLOAT AS postgis_v;
-- ERROR:  invalid input syntax for type double precision: "9.6.16"
```

This PR adds semantic versioning parsing and also supports the edge case where PostgreSQL or PostGIS return a partial semver, e.g. `12.1`.

If you run this against PostgreSQL 9, you should get

> thread 'main' panicked at 'ERROR: Hecate requires a min PostgreSQL version of >= 11.0.0, got 9.6.16.', hecate/src/main.rs:157:29

I also bumped the required PostgreSQL and PostGIS versions to what seems best.

cc/ @ingalls
