### PR TITLE
Fix deprecation warning (Error::Description)

### DIFF
--- a/hecate/src/main.rs
+++ b/hecate/src/main.rs
@@ -157,7 +157,7 @@ fn database_check(conn_str: &String, is_read: bool) {
                     },
                     Err(err) => {
                         println!("ERROR: Connection unable obtain postgres version using ({}) {}", conn_type, conn_str);
-                        println!("ERROR: {}", err.description());
+                        println!("ERROR: {}", err);
                         println!("ERROR: Caused by: {}", err.source().unwrap());
                         std::process::exit(1);
                     }
@@ -170,7 +170,7 @@ fn database_check(conn_str: &String, is_read: bool) {
                 Ok(_) => (),
                 Err(err) => {
                     println!("ERROR: Connection unable to {} geo table using {}", conn_type, conn_str);
-                    println!("ERROR: {}", err.description());
+                    println!("ERROR: {}", err);
                     println!("ERROR: Caused by: {}", err.source().unwrap());
                     std::process::exit(1);
                 }
@@ -178,7 +178,7 @@ fn database_check(conn_str: &String, is_read: bool) {
         },
         Err(err) => {
             println!("ERROR: Unable to connect to {}", conn_str);
-            println!("ERROR: {}", err.description());
+            println!("ERROR: {}", err);
             println!("ERROR: caused by: {}", err.source().unwrap());
 
             std::process::exit(1);


### PR DESCRIPTION
### Context

In Rust 1.42  Error::Description is deprecated.

These calls to .description() can be removed
because the Error trait implements Display and Debug.

https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#error:description-is-deprecated

cc/ @ingalls
