### PR TITLE
Fix clippy error strict comparison of `f32` or `f64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +944,7 @@ dependencies = [
  "actix-service 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-threadpool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2695,6 +2704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"

--- a/hecate/Cargo.toml
+++ b/hecate/Cargo.toml
@@ -41,6 +41,7 @@ env_logger = "0.7"
 hmac = "0.7"
 url = "2.1"
 sha2 = "0.8.0"
+approx = "0.3"
 
 [dependencies.geo]
 version = "0.12"

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -9,6 +9,7 @@ pub static HOURS: i64 = 24;
 ///
 pub static MAX_BODY: u64 = 20_971_520;
 
+#[macro_use] extern crate approx;
 #[macro_use] extern crate serde_json;
 #[macro_use] extern crate serde_derive;
 

--- a/hecate/src/osm/mod.rs
+++ b/hecate/src/osm/mod.rs
@@ -9,6 +9,7 @@ use crate::osm::way::Way;
 use crate::osm::rel::Rel;
 use crate::osm::tree::OSMTree;
 
+
 use std::string;
 use std::num;
 use std::io::Cursor;
@@ -897,7 +898,7 @@ pub fn parse_osm(xml_node: &XMLEvents::BytesStart, meta: &mut HashMap<String, St
         None => { return Err(XMLError::InternalError(String::from("version required"))); }
     };
 
-    if v != 0.6 { return Err(XMLError::InternalError(String::from("api only supports 0.6"))); }
+    if relative_ne!(v, 0.6) { return Err(XMLError::InternalError(String::from("api only supports 0.6"))); }
 
     Ok(true)
 }


### PR DESCRIPTION

### Context

- use `approx` crate for floating point comparison

Fixes #13

cc/ @ingalls
